### PR TITLE
Fix mismatch of Greek letters iota and zeta

### DIFF
--- a/markdown-latex.html
+++ b/markdown-latex.html
@@ -397,7 +397,7 @@ H3
 <td><span class="math inline">\(\vartheta\)</span> <code>\vartheta</code></td>
 </tr>
 <tr class="odd">
-<td><span class="math inline">\(\iota\)</span> <code>\zeta</code></td>
+<td><span class="math inline">\(\iota\)</span> <code>\iota</code></td>
 <td><span class="math inline">\(I\)</span> <code>I</code></td>
 <td></td>
 </tr>


### PR DESCRIPTION
Whilst reading the [Markdown and LaTeX introduction](https://ashki23.github.io/markdown-latex.html) page on this website, I noticed an error in the `Greek alphabets` section, which this PR corrects.  Thanks for great informative content, BTW!